### PR TITLE
File input test fix

### DIFF
--- a/projects/dxc-ngx-cdk/src/lib/dxc-file-input/dxc-file-input.component.spec.ts
+++ b/projects/dxc-ngx-cdk/src/lib/dxc-file-input/dxc-file-input.component.spec.ts
@@ -82,9 +82,8 @@ describe("DxcFileInputComponent", () => {
       type: "text/plain",
     });
     fireEvent.change(inputEl, { target: { files: [file] } });
-    await waitFor(() => {
-      expect(() => screen.getByText("foo.txt")).toThrow();
-    });
+    const fileInScreen = screen.queryByText("foo.txt");
+    expect(fileInScreen).toBeFalsy();
   });
 
   test("should render error when file does not meet minSize", async () => {


### PR DESCRIPTION
Removing expect(() => ) from tests since it is not working as we expected.